### PR TITLE
feat: add LogLevel type for custom log level mapping

### DIFF
--- a/getenv.go
+++ b/getenv.go
@@ -32,6 +32,7 @@ var (
 	_ Value = (*float64Value)(nil)
 	_ Value = (*durationValue)(nil)
 	_ Value = (*tcpAddrValue)(nil)
+	_ Value = (*logLevelValue)(nil)
 )
 
 // EnvironmentVariable represents environment variable.
@@ -121,6 +122,14 @@ func (e *EnvironmentVariableSet) StringSlice(name string, value []string) *[]str
 	return p
 }
 
+// LogLevel creates new log level.
+func (e *EnvironmentVariableSet) LogLevel(name string, levels map[string]int, value int) *int {
+	p := new(int)
+	e.LogLevelVar(p, name, levels, value)
+
+	return p
+}
+
 // BoolVar creates new bool variable.
 func (e *EnvironmentVariableSet) BoolVar(p *bool, name string, value bool) {
 	e.Var(newBoolValue(value, p), name)
@@ -159,6 +168,11 @@ func (e *EnvironmentVariableSet) TCPAddrVar(p *string, name string, value string
 // StringSliceVar creates new string slice variable.
 func (e *EnvironmentVariableSet) StringSliceVar(p *[]string, name string, value []string) {
 	e.Var(newStringSliceValue(value, p), name)
+}
+
+// LogLevelVar creates new log level variable.
+func (e *EnvironmentVariableSet) LogLevelVar(p *int, name string, levels map[string]int, value int) {
+	e.Var(newLogLevelValue(levels, value, p), name)
 }
 
 // Parse fetches environment variable, creates required Value, sets and stores.

--- a/getenv_test.go
+++ b/getenv_test.go
@@ -778,3 +778,30 @@ func TestLogLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestLogLevelWithLowercaseMapKeys(t *testing.T) {
+	os.Setenv("TEST_LOGLEVEL_LOWERCASE", "DEBUG")
+
+	defer func() {
+		os.Unsetenv("TEST_LOGLEVEL_LOWERCASE")
+	}()
+
+	// map keys are lowercase/mixed case
+	levels := map[string]int{
+		"debug": 0,
+		"Info":  1,
+		"WARN":  2,
+		"error": 3,
+	}
+
+	val := getenv.LogLevel("TEST_LOGLEVEL_LOWERCASE", levels, 1)
+	err := getenv.Parse()
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if *val != 0 {
+		t.Errorf("want [0], got: [%d]", *val)
+	}
+	getenv.Reset()
+}

--- a/loglevel.go
+++ b/loglevel.go
@@ -13,7 +13,13 @@ type logLevelValue struct {
 func newLogLevelValue(levels map[string]int, def int, p *int) *logLevelValue {
 	*p = def
 
-	return &logLevelValue{val: p, levels: levels}
+	// normalize level keys to uppercase for case-insensitive lookup
+	normalizedLevels := make(map[string]int, len(levels))
+	for k, v := range levels {
+		normalizedLevels[strings.ToUpper(k)] = v
+	}
+
+	return &logLevelValue{val: p, levels: normalizedLevels}
 }
 
 func (l *logLevelValue) Set(s string) error {

--- a/loglevel.go
+++ b/loglevel.go
@@ -1,0 +1,35 @@
+package getenv
+
+import (
+	"fmt"
+	"strings"
+)
+
+type logLevelValue struct {
+	val    *int
+	levels map[string]int
+}
+
+func newLogLevelValue(levels map[string]int, def int, p *int) *logLevelValue {
+	*p = def
+
+	return &logLevelValue{val: p, levels: levels}
+}
+
+func (l *logLevelValue) Set(s string) error {
+	key := strings.ToUpper(strings.TrimSpace(s))
+	if v, ok := l.levels[key]; ok {
+		*l.val = v
+
+		return nil
+	}
+
+	return fmt.Errorf("[%w] unknown log level %q", ErrInvalid, s)
+}
+
+func (l *logLevelValue) Get() any { return *l.val }
+
+// LogLevel sets environment variable and returns the pointer of value.
+func LogLevel(name string, levels map[string]int, defaultValue int) *int {
+	return environmentVariableSetInstance.LogLevel(name, levels, defaultValue)
+}


### PR DESCRIPTION
## Summary

- Adds `LogLevel` type that maps string log levels (DEBUG, INFO, WARN, ERROR, etc.) to integer values
- Custom level definitions via `map[string]int`
- Case-insensitive matching (debug = DEBUG = Debug)
- Returns `ErrInvalid` for unknown levels
- Updates README with `StringSlice` and `LogLevel` documentation

Closes #2

## Usage

```go
levels := map[string]int{
    "DEBUG": 0,
    "INFO":  1,
    "WARN":  2,
    "ERROR": 3,
}
logLevel := getenv.LogLevel("LOG_LEVEL", levels, 1) // default INFO
```

## Test plan

- [x] Unit tests for default value
- [x] Unit tests for valid levels (DEBUG, INFO, etc.)
- [x] Unit tests for case-insensitive matching
- [x] Unit tests for unknown level error
- [x] Example test
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)